### PR TITLE
direct database access via Python utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,13 @@ node_modules
 
 *.ipynb_checkpoints
 
-# Python packages
+# Python 
 
+*.pyc
 *.egg-info
+*/*/*/__pycache__/
+*/*/__pycache__/
+*/__pycache__/
 
 # Secrets
 .env*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 node_modules
 
+# Jupyter notebooks
+
+*.ipynb_checkpoints
+
+# Python packages
+
+*.egg-info
+
 # Secrets
 .env*
 

--- a/csodb.yml
+++ b/csodb.yml
@@ -1,0 +1,17 @@
+name: csodb
+channels:
+- conda-forge
+- digitalglobe
+dependencies:
+- python=3.7
+- jupyter
+- geopandas
+- geojson
+- gdal
+- pandas
+- folium
+- cartopy
+- sqlalchemy
+- psycopg2
+- jupyterlab 
+- pyyaml

--- a/csodb.yml
+++ b/csodb.yml
@@ -1,14 +1,11 @@
 name: csodb
 channels:
 - conda-forge
-- digitalglobe
 dependencies:
 - python=3.7
 - jupyter
 - geopandas
 - geojson
-- gdal
-- pandas
 - folium
 - cartopy
 - sqlalchemy

--- a/csodbpy/utils.py
+++ b/csodbpy/utils.py
@@ -1,0 +1,14 @@
+def startEngine(connectionString):
+   '''
+   Instantiates a database connection from a list of credentials
+   connectionString: dictionary of database credentials
+   returns: SQLAlchemy database engine
+   '''
+
+   from sqlalchemy import create_engine
+
+   cs = connectionString
+   
+   engine = create_engine('postgresql://' + cs['SQL_USERNAME'] + ':' + cs['SQL_PASSWORD'] + '@' + cs['SQL_HOSTNAME'] + ':' + cs['SQL_PORT'] + '/' + cs['SQL_DATABASE'])
+
+   return engine 

--- a/csodbpy/utils.py
+++ b/csodbpy/utils.py
@@ -6,9 +6,19 @@ def startEngine(connectionString):
    '''
 
    from sqlalchemy import create_engine
+   from sqlalchemy.engine.url import URL as dburl
 
    cs = connectionString
-   
-   engine = create_engine('postgresql://' + cs['SQL_USERNAME'] + ':' + cs['SQL_PASSWORD'] + '@' + cs['SQL_HOSTNAME'] + ':' + cs['SQL_PORT'] + '/' + cs['SQL_DATABASE'])
+
+   dbconfig = {
+    "drivername": "postgresql",
+    "username": cs['SQL_USERNAME'],
+    "password": cs['SQL_PASSWORD'],
+    "host":cs['SQL_HOSTNAME'],
+    "port": cs['SQL_PORT'],
+    "database": cs['SQL_DATABASE']
+    }
+
+   engine = create_engine(dburl(**dbconfig)) 
 
    return engine 

--- a/notebooks/CSO database updates.ipynb
+++ b/notebooks/CSO database updates.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CSO database updates\n",
+    "\n",
+    "This notebook sets up tools to interface directly with the NASA CSO database using Pandas and SQL queries.\n",
+    "\n",
+    "Anthony Arendt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, sys\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import glob \n",
+    "from geopandas import GeoSeries, GeoDataFrame\n",
+    "import yaml\n",
+    "\n",
+    "from csodbpy import utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/arendta/anaconda3/envs/csodb/lib/python3.7/site-packages/ipykernel_launcher.py:2: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.\n",
+      "  \n"
+     ]
+    }
+   ],
+   "source": [
+    "# load yml file to dictionary\n",
+    "credentials = yaml.load(open('../.env.yaml'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Establish connection to Postgres database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine = utils.startEngine(credentials)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Use Pandas to issue SQL statements to the database.\n",
+    "\n",
+    "We can now use this to import new data into the database.\n",
+    "\n",
+    "Here's a simple test query:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_sql(\"SELECT * FROM observations WHERE author = 'Anthony Arendt'\", engine)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>author</th>\n",
+       "      <th>depth</th>\n",
+       "      <th>source</th>\n",
+       "      <th>elevation</th>\n",
+       "      <th>location</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>t38/+wzw</td>\n",
+       "      <td>Anthony Arendt</td>\n",
+       "      <td>51.999998</td>\n",
+       "      <td>MountainHub</td>\n",
+       "      <td>1718.054443</td>\n",
+       "      <td>0101000020E61000007E326BCEE6C65CC0F71F990E9D54...</td>\n",
+       "      <td>2018-01-09 21:34:06.751</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>sYef/5nt</td>\n",
+       "      <td>Anthony Arendt</td>\n",
+       "      <td>45.999998</td>\n",
+       "      <td>MountainHub</td>\n",
+       "      <td>1729.596680</td>\n",
+       "      <td>0101000020E610000092729C804BC65CC0A3C629DFD855...</td>\n",
+       "      <td>2018-01-09 20:45:07.869</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>S5id1Rny</td>\n",
+       "      <td>Anthony Arendt</td>\n",
+       "      <td>20.999999</td>\n",
+       "      <td>MountainHub</td>\n",
+       "      <td>72.866943</td>\n",
+       "      <td>0101000020E610000005F8133A54915EC0FB021F285CC6...</td>\n",
+       "      <td>2019-02-04 21:04:51.267</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         id          author      depth       source    elevation  \\\n",
+       "0  t38/+wzw  Anthony Arendt  51.999998  MountainHub  1718.054443   \n",
+       "1  sYef/5nt  Anthony Arendt  45.999998  MountainHub  1729.596680   \n",
+       "2  S5id1Rny  Anthony Arendt  20.999999  MountainHub    72.866943   \n",
+       "\n",
+       "                                            location               timestamp  \n",
+       "0  0101000020E61000007E326BCEE6C65CC0F71F990E9D54... 2018-01-09 21:34:06.751  \n",
+       "1  0101000020E610000092729C804BC65CC0A3C629DFD855... 2018-01-09 20:45:07.869  \n",
+       "2  0101000020E610000005F8133A54915EC0FB021F285CC6... 2019-02-04 21:04:51.267  "
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/CSO database updates.ipynb
+++ b/notebooks/CSO database updates.ipynb
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -164,7 +164,7 @@
        "2  0101000020E610000005F8133A54915EC0FB021F285CC6... 2019-02-04 21:04:51.267  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
+
+import os
+
+from codecs import open
+
+from setuptools import find_packages, setup
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
+
+setup(name='csodbpy',
+    version='0.1.0',
+    description='Libraries and utilities for accessing NASA Community Snow Observations database',
+    author='Anthony Arendt',
+    author_email='arendta@uw.edu',
+    license='MIT',
+    url='https://github.com/communitysnowobs/cso-api',
+    packages=find_packages(),
+    long_description=long_description
+)


### PR DESCRIPTION
This adds Python utilities and a sample notebook for direct access to the NASA CSO database. The motivation here is to enable custom queries as well as updates to the database for one-time data updates.

The Python utilities use SQLAlchemy for creating the database connection engine and Pandas is used for issuing SQL statements to the database.

@jonahjoughin let me know if you agree with this content belonging in this repo. Otherwise I can add it elsewhere.